### PR TITLE
Fix unterminated regexp literal in latex renderer

### DIFF
--- a/src/utils/latexRenderer.tsx
+++ b/src/utils/latexRenderer.tsx
@@ -1,0 +1,27 @@
+import React from 'react';
+import 'katex/dist/katex.min.css';
+import { InlineMath, BlockMath } from 'react-katex';
+
+export const renderMathContent = (content: string): React.ReactNode => {
+  // Check if content contains LaTeX delimiters
+  if (content.includes('$') && content.startsWith('$') && content.endsWith('$')) {
+    // Remove the $ delimiters and render as inline math
+    const latexContent = content.slice(1, -1);
+    return <InlineMath>{latexContent}</InlineMath>;
+  }
+  
+  // Check for block math ($$...$$)
+  if (content.includes('$$') && content.startsWith('$$') && content.endsWith('$$')) {
+    // Remove the $$ delimiters and render as block math
+    const latexContent = content.slice(2, -2);
+    return <BlockMath>{latexContent}</BlockMath>;
+  }
+  
+  // If no LaTeX delimiters, render as regular text
+  return content;
+};
+
+export const isLatexContent = (content: string): boolean => {
+  return (content.includes('$') && content.startsWith('$') && content.endsWith('$')) ||
+         (content.includes('$$') && content.startsWith('$$') && content.endsWith('$$'));
+};


### PR DESCRIPTION
Rename `latexRenderer.ts` to `latexRenderer.tsx` to resolve a syntax error caused by JSX in a `.ts` file.

The previous `.ts` file could not parse JSX syntax, leading to an "Unterminated regexp literal" error. Renaming it to `.tsx` allows the file to correctly interpret and render React components for LaTeX.

---
<a href="https://cursor.com/background-agent?bcId=bc-0474696b-658a-4f22-a9ba-69ce7f08a0a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg">
    <img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg">
  </picture>
</a>
<a href="https://cursor.com/agents?id=bc-0474696b-658a-4f22-a9ba-69ce7f08a0a3">
  <picture>
    <source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg">
    <source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg">
    <img alt="Open in Web" src="https://cursor.com/open-in-web.svg">
  </picture>
</a>

<sub>[Learn more](https://docs.cursor.com/background-agent/web-and-mobile) about Cursor Agents</sub>